### PR TITLE
Check null connection in PhoenixIoConnection

### DIFF
--- a/lib/src/phoenix_io_connection.dart
+++ b/lib/src/phoenix_io_connection.dart
@@ -63,7 +63,7 @@ class PhoenixIoConnection extends PhoenixConnection {
   }
 
   void onMessage(void callback(String? m)) {
-    _conn?.listen((e) {
+    _conn?.asBroadcastStream().listen((e) {
       callback(_messageToString(e));
     }, onDone: () {
       _closed.complete();

--- a/lib/src/phoenix_io_connection.dart
+++ b/lib/src/phoenix_io_connection.dart
@@ -39,7 +39,7 @@ class PhoenixIoConnection extends PhoenixConnection {
   void send(String data) {
     if (isConnected) {
       try {
-        _conn!.add(data);
+        _conn?.add(data);
       } catch (e) {
         log((e as dynamic).message);
       }
@@ -53,8 +53,8 @@ class PhoenixIoConnection extends PhoenixConnection {
   }
 
   void onError(void callback(dynamic)) {
-    _conn!.handleError(callback);
-    _conn!.done.catchError(callback);
+    _conn?.handleError(callback);
+    _conn?.done.catchError(callback);
   }
 
   String? _messageToString(dynamic e) {
@@ -63,7 +63,7 @@ class PhoenixIoConnection extends PhoenixConnection {
   }
 
   void onMessage(void callback(String? m)) {
-    _conn!.listen((e) {
+    _conn?.listen((e) {
       callback(_messageToString(e));
     }, onDone: () {
       _closed.complete();


### PR DESCRIPTION
- Check null connection

> `_CastError phoenix_io_connection.dart in PhoenixIoConnection.onMessage`

> Null check operator used on a null value

> phoenix_io_connection.dart in PhoenixIoConnection.onMessage at line 66 within phoenix_wings

> phoenix_socket.dart in PhoenixSocket.connect at line 116 within phoenix_wings

- Update method `onMessage` Broadcast Stream


> Bad state: Stream has already been listened to.

> phoenix_io_connection.dart in PhoenixIoConnection.onMessage at line 66 within phoenix_wings

> phoenix_socket.dart in PhoenixSocket.connect at line 116 within phoenix_wings